### PR TITLE
Fixed QR code occasionally using the wrong adapter's IP

### DIFF
--- a/plugins/TidalWave/src/native/qrHelper.native.ts
+++ b/plugins/TidalWave/src/native/qrHelper.native.ts
@@ -19,7 +19,9 @@ function getPreferredLocalIPv4(): string {
     const interfaces = os.networkInterfaces();
     const candidates: { ip: string; priority: number }[] = [];
 
-    for (const ifaceList of Object.values(interfaces)) {
+    for (const name of Object.keys(interfaces)) {
+        if (!(name.toLowerCase().includes("ethernet") || name.toLowerCase().includes("wireless"))) continue;
+        const ifaceList = interfaces[name];
         if (!ifaceList) continue;
         for (const iface of ifaceList) {
             if (iface.family === "IPv4" && !iface.internal) {


### PR DESCRIPTION
On my system, a nordvpn network adapter was listed before my ethernet adapter, so the QR code was using that adapters IP.  I have added a check for the name of the network adapter including "ethernet" or "wireless" to mitigate this issue.